### PR TITLE
Fix markdown syntax for props tables

### DIFF
--- a/src/pages/docs/reference/Math.md
+++ b/src/pages/docs/reference/Math.md
@@ -18,7 +18,7 @@ el.in({channel: 2}, w, x, y, z); // Equivalent to `y`
 #### Props
 
 | Name     | Default  | Type   | Description                            |
-| -------- | -------- | ----------------------------------------------- |
+| -------- | -------- | -------|--------------------------------------- |
 | channel  | 0        | Number | Selects which input channel to forward |
 
 ### el.sin

--- a/src/pages/docs/reference/const.md
+++ b/src/pages/docs/reference/const.md
@@ -19,7 +19,7 @@ el.cycle(el.const({value: 440}))
 #### Props
 
 | Name     | Default  | Type   | Description                            |
-| -------- | -------- | ----------------------------------------------- |
+| -------- | -------- | -------|--------------------------------------- |
 | value    | 0        | Number | Declare's the node's output value      |
 
 

--- a/src/pages/docs/reference/meter.md
+++ b/src/pages/docs/reference/meter.md
@@ -40,6 +40,6 @@ core.on('meter', function(e) {
 #### Props
 
 | Name     | Default   | Type   | Description                            |
-| -------- | --------- | ----------------------------------------------- |
+| -------- | --------- | -------|--------------------------------------- |
 | name     | undefined | String | Identifies a meter node by name        |
 

--- a/src/pages/docs/reference/metro.md
+++ b/src/pages/docs/reference/metro.md
@@ -79,6 +79,6 @@ metro event objects.
 #### Props
 
 | Name     | Default   | Type   | Description                            |
-| -------- | --------- | ----------------------------------------------- |
+| -------- | --------- | -------|--------------------------------------- |
 | name     | undefined | String | Identifies a metro node by name        |
 | interval | undefined | Number | Metronome period in milliseconds       |

--- a/src/pages/docs/reference/scope.md
+++ b/src/pages/docs/reference/scope.md
@@ -50,7 +50,7 @@ Multi-channel synchronization through the scope node itself requires only:
 #### Props
 
 | Name     | Default   | Type   | Description                            |
-| -------- | --------- | ----------------------------------------------- |
+| -------- | --------- | -------|--------------------------------------- |
 | name     | undefined | String | Identifies a scope node by name        |
 | size     | 512       | Number | Block size to buffer and report to js  |
 | channels | 1         | Number | The number of children to report on    |

--- a/src/pages/docs/reference/seq.md
+++ b/src/pages/docs/reference/seq.md
@@ -23,7 +23,7 @@ el.sample(
 #### Props
 
 | Name     | Default  | Type   | Description                                                              |
-| -------- | -------- | --------------------------------------------------------------------------------- |
+| -------- | -------- | -------|------------------------------------------------------------------------- |
 | seq      | []       | Array  | The sequence of values to generate                                       |
 | offset   | 0        | number | The offset index to reset to on the rising edge of the reset signal      |
 | hold     | false    | Bool   | When true, continues to output the sequence value until the next trigger |

--- a/src/pages/docs/reference/seq2.md
+++ b/src/pages/docs/reference/seq2.md
@@ -31,7 +31,7 @@ el.sample(
 #### Props
 
 | Name     | Default  | Type   | Description                                                              |
-| -------- | -------- | --------------------------------------------------------------------------------- |
+| -------- | -------- | -------|------------------------------------------------------------------------- |
 | seq      | []       | Array  | The sequence of values to generate                                       |
 | offset   | 0        | number | The sequence offset value                                                |
 | hold     | false    | Bool   | When true, continues to output the sequence value until the next trigger |


### PR DESCRIPTION
Some of the props tables are not rendering correctly on the website due to a table syntax error, e.g. [el.seq](https://www.elementary.audio/docs/reference/seq)

<img width="793" alt="image" src="https://github.com/elemaudio/website/assets/115310/cde3b22f-8e69-48de-8933-e12dcc80938c">
