### PR TITLE
Removed size prop from example

### DIFF
--- a/src/pages/docs/reference/tapIn.md
+++ b/src/pages/docs/reference/tapIn.md
@@ -11,7 +11,7 @@ as follows:
 
 ```js
 core.render(
-  el.tapOut({name: 'a', size: 22050},
+  el.tapOut({name: 'a'},
     el.mul(
       0.5,
       el.add(


### PR DESCRIPTION
The example contained a `{size: 22050}` prop which is not part of the spec. 