### PR TITLE
Change sphasor references to syncphasor

### DIFF
--- a/src/pages/docs/reference/_meta.json
+++ b/src/pages/docs/reference/_meta.json
@@ -60,7 +60,7 @@
   "snapshot": "el.snapshot",
   "sparseq": "el.sparseq",
   "sparseq2": "el.sparseq2",
-  "sphasor": "el.sphasor",
+  "syncphasor": "el.syncphasor",
   "square": "el.square",
   "sr": "el.sr",
   "svf": "el.svf",

--- a/src/pages/docs/reference/phasor.md
+++ b/src/pages/docs/reference/phasor.md
@@ -3,4 +3,4 @@
 Outputs a ramp from 0 to 1 at the given rate. Expects one child signal
 providing the ramp rate in `hz`.
 
-For the same signal with phase reset behavior, see [el.sphasor](./sphasor).
+For the same signal with phase reset behavior, see [el.syncphasor](./syncphasor).

--- a/src/pages/docs/reference/syncphasor.md
+++ b/src/pages/docs/reference/syncphasor.md
@@ -1,4 +1,4 @@
-# el.sphasor(rate, reset)
+# el.syncphasor(rate, reset)
 
 Outputs a ramp from 0 to 1 at the given rate. Expects two children, the first
 providing the ramp rate in `hz`, the second a pulse train for resetting the


### PR DESCRIPTION
As mentioned on Discord, the docs refer to `sphasor` but the export is actually `syncphasor` - only later realised the website is public so here's my PR!